### PR TITLE
fix(quiz): sync currentQuestionIndex with answers.length on quiz resume

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,24 @@ GitHub Pages SPAデプロイメント対応のため、Hash routingを採用：
 - **保守性**: テストコードも製品コードと同等の保守性基準を適用
 - **ROI重視**: テスト価値 vs 保守コストの定量的判断
 
+### Issue #10 修正: クイズ再開時の問題（2025-08-09）
+
+#### 問題の詳細
+- **現象**: 「続きから」でクイズを再開すると、回答済みの問題から再開される
+- **原因**: `submitAnswer()`が`currentQuestionIndex`を更新せず、`answers.length`と同期しない
+- **影響**: ユーザーが既に回答した問題を再度回答する必要があった
+
+#### 修正内容
+- **実装**: `src/stores/quiz-store.ts`の`startQuiz`メソッドを修正（206-209行目）
+- **ロジック**: 既存進捗を返す際に`currentQuestionIndex`を`Math.max(currentQuestionIndex, answers.length)`で同期
+- **テスト**: `test/stores/quiz-store.test.ts`に再現テストケースを追加（250-270行目）
+
+#### 技術的学習
+- **状態管理の整合性**: 複数の状態（`currentQuestionIndex`と`answers`）の同期が重要
+- **TDDによるバグ修正**: バグを再現するテストを先に作成してから修正
+- **Playwright検証**: 実際のユーザーフローでの動作確認の重要性
+- **テスト成果**: 全130テスト成功、Biome静的解析クリア
+
 ## 重要な実装知見
 
 ### 現在の技術債務・制約事項

--- a/docs/02_tasks.md
+++ b/docs/02_tasks.md
@@ -343,6 +343,10 @@ test/
 - ✅ **問題ID仕様の明確化**（2025-08-02）：
   - 問題には明示的なIDを付与せず、配列インデックスを使用
   - 手動ID管理の保守コスト削減のための設計決定
+- ✅ **Issue #10: クイズ再開時の問題**（2025-08-09）：
+  - 「続きから」で回答済み問題から再開される問題を修正
+  - `startQuiz`メソッドで`currentQuestionIndex`を`answers.length`と同期
+  - テストケース追加（全130テスト成功）
 
 ### 今後検討事項
 - YAML plugin（@modyfi/vite-plugin-yaml）の動的import対応

--- a/src/stores/quiz-store.ts
+++ b/src/stores/quiz-store.ts
@@ -199,7 +199,6 @@ export const quizStateManager = {
         existing.currentQuestionIndex >= totalQuestions;
 
       if (!isCompleted) {
-        // 未完了の場合：既存の進捗を返す
         // currentQuestionIndexを実際の回答進捗と同期
         const syncedProgress = {
           ...existing,

--- a/src/stores/quiz-store.ts
+++ b/src/stores/quiz-store.ts
@@ -200,7 +200,15 @@ export const quizStateManager = {
 
       if (!isCompleted) {
         // 未完了の場合：既存の進捗を返す
-        return existing;
+        // currentQuestionIndexを実際の回答進捗と同期
+        const syncedProgress = {
+          ...existing,
+          currentQuestionIndex: Math.max(
+            existing.currentQuestionIndex,
+            existing.answers.length,
+          ),
+        };
+        return syncedProgress;
       }
     }
 

--- a/test/stores/quiz-store.test.ts
+++ b/test/stores/quiz-store.test.ts
@@ -246,6 +246,29 @@ describe("QuizStateManager", () => {
       expect(progress?.completedAt).toBeDefined();
       expect(typeof progress?.completedAt).toBe("string");
     });
+
+    it("回答後にホームに戻り、続きから再開すると次の未回答問題から始まる", () => {
+      // 1問目に回答（nextQuestionを呼ばずに）
+      QuizStateManager.submitAnswer({
+        categoryId: "programming",
+        questionIndex: 0,
+        selectedOptions: [1],
+        correctOptions: [1],
+      });
+
+      // この時点でcurrentQuestionIndexは0のまま、answersは1つ
+      const progressBeforeResume =
+        QuizStateManager.getCategoryProgress("programming");
+      expect(progressBeforeResume?.currentQuestionIndex).toBe(0);
+      expect(progressBeforeResume?.answers).toHaveLength(1);
+
+      // ホームに戻った後、続きから再開
+      const resumedProgress = QuizStateManager.startQuiz("programming", 10);
+
+      // currentQuestionIndexがanswers.lengthと同期されて1になるべき
+      expect(resumedProgress.currentQuestionIndex).toBe(1);
+      expect(resumedProgress.answers).toHaveLength(1);
+    });
   });
 
   describe("復習機能", () => {


### PR DESCRIPTION
## Summary
Fixes #10 - "Continue from" button now correctly resumes from the next unanswered question instead of replaying already answered questions.

## Problem
When a user answered a question but returned home without clicking "Next Question", the quiz would restart from the already-answered question when resumed via "Continue from" button. This was because `currentQuestionIndex` wasn't synchronized with the actual progress (`answers.length`).

## Solution
Modified the `startQuiz` method in `quiz-store.ts` to synchronize `currentQuestionIndex` with `answers.length` when returning existing progress:
```typescript
const syncedProgress = {
  ...existing,
  currentQuestionIndex: Math.max(
    existing.currentQuestionIndex,
    existing.answers.length,
  ),
};
```

## Test Results
- ✅ Added specific test case for this scenario
- ✅ All 130 tests passing
- ✅ Biome static analysis clean
- ✅ Build successful
- ✅ Verified with Playwright E2E testing

## Verification Steps
1. Start Web基礎 category quiz
2. Answer question 1
3. Click "ホームに戻る" without clicking "次の問題"
4. Click "続きから" button
5. Confirm that question 2 is displayed (not question 1)

🤖 Generated with [Claude Code](https://claude.ai/code)