### PR TITLE
YAML ファイルスキーマの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ metadata:                      # クイズ全体のメタデータ（必須）
   version: "1.0.0"            # バージョン番号
   title: "問題集のタイトル"       # 問題集の名称
   lastUpdated: "2025-01-15"   # 最終更新日（YYYY-MM-DD 形式）
-  totalQuestions: 10          # 問題総数（実際の問題数と一致する必要あり）
   description: "説明文"        # 問題集の説明（オプション）
 
 categories:                    # 問題カテゴリの配列（最低1つ必要）
@@ -96,7 +95,6 @@ categories:                    # 問題カテゴリの配列（最低1つ必要�
 - `version`: 問題集のバージョン番号（文字列）
 - `title`: 問題集のタイトル（文字列）
 - `lastUpdated`: 最終更新日（`YYYY-MM-DD` 形式の文字列）
-- `totalQuestions`: 問題の総数（数値、実際の問題数と一致必須）
 - `description`: 問題集の説明（文字列、オプション）
 
 **カテゴリ (`categories`):**
@@ -144,7 +142,6 @@ metadata:
   version: "1.0.0"
   title: "JavaScript 基礎問題集"
   lastUpdated: "2025-01-15"
-  totalQuestions: 2
   description: "JavaScript の基本文法を学ぶ問題集"
 
 categories:

--- a/docs/00_requirements.md
+++ b/docs/00_requirements.md
@@ -166,8 +166,8 @@ metadata:
   version: "1.0.0"                    # データ形式バージョン
   title: "問題集タイトル"              # 問題集名
   lastUpdated: "2025-07-19"           # 最終更新日（YYYY-MM-DD）
-  totalQuestions: 150                  # 総問題数
   description: "問題集の説明"          # 説明文（オプション）
+  # 注意: totalQuestions フィールドは不要（自動計算される）
 
 # カテゴリ配列
 categories:

--- a/src/data/quiz.yaml
+++ b/src/data/quiz.yaml
@@ -2,7 +2,6 @@ metadata:
   version: "1.0.0"
   title: "サンプル問題集"
   lastUpdated: "2025-07-21"
-  totalQuestions: 4
   description: "テスト用のサンプル問題集"
 
 categories:

--- a/src/schema/quiz.ts
+++ b/src/schema/quiz.ts
@@ -220,7 +220,7 @@ export type QuizData = {
  * @param valibotPath - Path array from Valibot validation issue
  * @returns Formatted field path string
  */
-function createFieldPath(valibotPath: Array<{ key: unknown }>): string {
+const createFieldPath = (valibotPath: Array<{ key: unknown }>): string => {
   if (!valibotPath || valibotPath.length === 0) return "";
 
   return valibotPath
@@ -233,7 +233,7 @@ function createFieldPath(valibotPath: Array<{ key: unknown }>): string {
     .join(".")
     .replace(/^\./, "") // Remove leading dot
     .replace(/\.\[/g, "["); // Clean up array notation
-}
+};
 
 /**
  * Maps Valibot error messages to application-specific error messages.
@@ -242,7 +242,7 @@ function createFieldPath(valibotPath: Array<{ key: unknown }>): string {
  * @param originalMessage - Original error message from Valibot
  * @returns Mapped error message
  */
-function mapErrorMessage(originalMessage: string): string {
+const mapErrorMessage = (originalMessage: string): string => {
   if (
     originalMessage.includes('Expected "metadata"') &&
     originalMessage.includes("undefined")
@@ -251,17 +251,17 @@ function mapErrorMessage(originalMessage: string): string {
   }
 
   return originalMessage;
-}
+};
 
 /**
  * Validates that all correct answer indices are within the valid range of options.
  * @param data - Question data to validate
  * @returns True if all indices are valid, false otherwise
  */
-function hasValidCorrectIndices(data: {
+const hasValidCorrectIndices = (data: {
   correct: unknown;
   options: unknown;
-}): boolean {
+}): boolean => {
   if (!Array.isArray(data.correct) || !Array.isArray(data.options)) {
     return true; // Skip validation if data structure is incomplete
   }
@@ -272,31 +272,31 @@ function hasValidCorrectIndices(data: {
       index >= 0 &&
       index < (data.options as unknown[]).length,
   );
-}
+};
 
 /**
  * Validates that single choice questions have exactly one correct answer.
  * @param data - Question data to validate
  * @returns True if validation passes, false otherwise
  */
-function hasSingleCorrectAnswer(data: {
+const hasSingleCorrectAnswer = (data: {
   type: unknown;
   correct: unknown;
-}): boolean {
+}): boolean => {
   if (data.type === "single" && Array.isArray(data.correct)) {
     return (
       data.correct.length === VALIDATION_CONSTANTS.SINGLE_CHOICE_CORRECT_COUNT
     );
   }
   return true;
-}
+};
 
 /**
  * Validates that category IDs are unique within the categories array.
  * @param categories - Array of categories to validate
  * @returns True if all IDs are unique, false otherwise
  */
-function hasUniqueCategories(categories: unknown[]): boolean {
+const hasUniqueCategories = (categories: unknown[]): boolean => {
   if (!Array.isArray(categories)) {
     return true; // Skip validation if data structure is incomplete
   }
@@ -304,7 +304,7 @@ function hasUniqueCategories(categories: unknown[]): boolean {
   const ids = categories.map((cat) => (cat as { id: unknown }).id);
   const uniqueIds = new Set(ids);
   return ids.length === uniqueIds.size;
-}
+};
 
 /**
  * Custom error class for quiz parsing failures.
@@ -357,10 +357,10 @@ export class QuizParseError extends Error {
  * // error.field: "quiz.metadata"
  * ```
  */
-function convertValibotError(
+const convertValibotError = (
   issues: v.BaseIssue<unknown>[],
   basePath: string = "",
-): QuizParseError {
+): QuizParseError => {
   const issue = issues[0]; // Take the first issue
 
   // Convert path using helper function
@@ -373,7 +373,7 @@ function convertValibotError(
   const message = mapErrorMessage(issue.message);
 
   return new QuizParseError(message, fullPath);
-}
+};
 
 /**
  * Parses and validates individual question data.


### PR DESCRIPTION
This pull request removes the need for a manually specified `totalQuestions` field in quiz metadata. Instead, the total number of questions is now automatically calculated during parsing, which simplifies the data format and reduces the chance of inconsistencies. The schema, documentation, and tests have all been updated to reflect this change.

**Schema and Parsing Logic Updates**
- Removed the `totalQuestions` field from the metadata schema and validation logic in `src/schema/quiz.ts`, and updated the `QuizData` type so that `totalQuestions` is calculated automatically during parsing. [[1]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L153) [[2]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48R200-R205) [[3]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48R404-R428)
- Refactored several helper functions in `src/schema/quiz.ts` to use arrow function syntax for consistency. [[1]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L226-R223) [[2]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L239-R236) [[3]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L248-R245) [[4]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L257-R264) [[5]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L278-R307) [[6]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L385-R363) [[7]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L401-R376)

**Error Handling and Messages**
- Removed the error message and validation for mismatched `totalQuestions` from the error messages and validation checks. [[1]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L60-L61) [[2]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L174-L177) [[3]](diffhunk://#diff-7f4236fe3c936a4c75c4f9d7a5fa5bf5d333d0bb4637de27e8089a7cab7a5f48L278-R307)

**Documentation Updates**
- Updated documentation in `README.md` and `docs/00_requirements.md` to remove references to the `totalQuestions` field, and added notes that it is now automatically calculated. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L99) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L147) [[4]](diffhunk://#diff-4a1983c024139649b7c570c9484900ffadbe90b03c8b5e16f46c02e6eaa38452L169-R170)

**Test Suite Adjustments**
- Updated tests in `test/schema/quiz.test.ts` to remove checks for manual `totalQuestions` and add tests verifying that the field is calculated automatically, including multi-category scenarios. [[1]](diffhunk://#diff-b3d02243f504251206c653637e8a3dd59099a70185472d0a0671490250109dfcL157) [[2]](diffhunk://#diff-b3d02243f504251206c653637e8a3dd59099a70185472d0a0671490250109dfcR194-R239) [[3]](diffhunk://#diff-b3d02243f504251206c653637e8a3dd59099a70185472d0a0671490250109dfcL248-L262) [[4]](diffhunk://#diff-b3d02243f504251206c653637e8a3dd59099a70185472d0a0671490250109dfcL303)

**Sample Data Updates**
- Removed the `totalQuestions` field from sample data in `src/data/quiz.yaml`.