### PR TITLE
fix: improve UI for questions which have long options

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ pnpm install --frozen-lockfile
 pnpm dev
 ```
 
+> [!NOTE]
+> `pnpm install` 時にエラーが発生する際は事前に `git init` するか、
+> [`package.json`](./package.json) 内の `scripts.postinstall` の業を削除してください。
+
 開発サーバーが起動したら `http://localhost:5173` でアプリケーションにアクセスできます。
 
 ### 問題データのカスタマイズ

--- a/src/components/quiz/AnswerOptions.tsx
+++ b/src/components/quiz/AnswerOptions.tsx
@@ -48,7 +48,8 @@ const AnswerOptions: Component<AnswerOptionsProps> = (props) => {
    * 選択肢のスタイルクラスを取得
    */
   const getOptionClasses = (optionIndex: number) => {
-    const baseClasses = "w-full text-left transition-all duration-200";
+    const baseClasses =
+      "w-full text-left transition-all duration-200 h-auto min-h-[3rem] whitespace-normal";
     const isSelected = props.selectedOptions.includes(optionIndex);
     const isCorrect = props.correctOptions?.includes(optionIndex);
     const isIncorrect = props.isAnswered && isSelected && !isCorrect;
@@ -101,7 +102,7 @@ const AnswerOptions: Component<AnswerOptionsProps> = (props) => {
                   props.isAnswered ? undefined : "selection-help"
                 }
               >
-                <div class="flex items-start gap-3 text-left w-full">
+                <div class="flex items-start gap-3 text-left w-full py-2 px-1">
                   {/* 回答後のみアイコンを表示 */}
                   <Show when={props.isAnswered}>
                     <span class="flex-shrink-0">
@@ -131,7 +132,9 @@ const AnswerOptions: Component<AnswerOptionsProps> = (props) => {
                   </Show>
 
                   {/* 選択肢テキスト */}
-                  <span class="flex-1 leading-relaxed">{option}</span>
+                  <span class="flex-1 leading-relaxed break-words">
+                    {option}
+                  </span>
                 </div>
               </button>
             );


### PR DESCRIPTION
This pull request mainly improves the user interface and usability of the quiz answer options, and adds a helpful note to the setup instructions in the `README.md`. The most important changes are grouped below:

**Documentation Improvements:**

* Added a note to the `README.md` to help users resolve errors when running `pnpm install`, suggesting to either run `git init` beforehand or remove the `scripts.postinstall` entry from `package.json`.

**Quiz Answer Options UI Enhancements (`src/components/quiz/AnswerOptions.tsx`):**

* Improved the base styling of answer option buttons to better handle longer text and ensure consistent sizing by adding `h-auto`, `min-h-[3rem]`, and `whitespace-normal`.
* Added padding (`py-2 px-1`) to the answer option container for better spacing and readability.
* Modified the option text to wrap long words and lines using `break-words`, preventing overflow and improving layout for lengthy options.