### PR TITLE
fix: fix skewed layout for mistake badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 [![Renovate: enable](https://img.shields.io/badge/renovate-enabled-brightgreen)](https://www.mend.io/renovate/)
-![GitHub Release Date](https://img.shields.io/github/release-date/mahito1594/quiz-app-template?label=release%2Fdeploy)
+[![GitHub Release Date](https://img.shields.io/github/release-date/mahito1594/quiz-app-template?label=release%2Fdeploy)](https://github.com/mahito1594/quiz-app-template/releases)
 
 
 ## 概要

--- a/e2e/review-mistakes.spec.ts
+++ b/e2e/review-mistakes.spec.ts
@@ -192,7 +192,7 @@ test.describe("Review Mistakes Journey", () => {
     await expect(
       page
         .locator(".card-body", { hasText: "プログラミング基礎" })
-        .getByText("1回間違い"),
+        .getByText("×1"),
     ).toBeVisible();
 
     // 3. 「復習を開始する」ボタンをクリック
@@ -243,7 +243,7 @@ test.describe("Review Mistakes Journey", () => {
     await expect(
       page
         .locator(".card-body", { hasText: "プログラミング基礎" })
-        .getByText("2回間違い"),
+        .getByText("×2"),
     ).toBeVisible();
 
     // 7. ホームに戻り「復習する」ボタンが表示されていることを確認

--- a/src/components/Review.tsx
+++ b/src/components/Review.tsx
@@ -39,7 +39,7 @@ const ReviewQuestionCard: Component<{
           </div>
           <div class="text-right">
             <div class="badge badge-error mb-1">
-              {props.reviewQuestion.errorCount}回間違い
+              &times;{props.reviewQuestion.errorCount}
             </div>
             <p class="text-xs text-base-content/60">
               {new Date(props.reviewQuestion.lastErrorAt).toLocaleDateString(


### PR DESCRIPTION
This pull request updates how the number of mistakes is displayed in both the UI and end-to-end tests, making the format more concise (from "n回間違い" to "×n"). It also fixes a minor issue in the `README.md` by turning a badge into a clickable link.

UI and test improvements:

* Changed the display of mistake counts from "n回間違い" to "×n" in the `ReviewQuestionCard` component for a clearer and more compact presentation.
* Updated related end-to-end tests in `e2e/review-mistakes.spec.ts` to match the new mistake count format ("×n" instead of "n回間違い"). [[1]](diffhunk://#diff-f80dc9bf32626c704b9581272ff8a77013ef6b86c8df3d571c673c70eeed1f7bL195-R195) [[2]](diffhunk://#diff-f80dc9bf32626c704b9581272ff8a77013ef6b86c8df3d571c673c70eeed1f7bL246-R246)

Documentation fix:

* Made the "GitHub Release Date" badge in `README.md` a clickable link to the releases page.