### PR TITLE
fix(renovate): add minimumReleaseAge of 1 day for npm packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,10 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
+    },
+    {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "1 day"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `renovate.json` の `packageRules` に `matchDatasources: ["npm"]` + `minimumReleaseAge: "1 day"` を追加
- pnpm v10+ のデフォルトサプライチェーンポリシー（24時間）と Renovate の採用タイミングを同期させる

## Background

PR #178 の CI が `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` で全ジョブ失敗した。
pnpm v10+ は公開から24時間以内のパッケージを `pnpm install --frozen-lockfile` 時にブロックするが、
Renovate は公開直後でも `pnpm-lock.yaml` を更新するため、タイミングによって CI が落ちていた。

`minimumReleaseAge: "1 day"` を設定することで Renovate が採用する時点で24時間経過済みとなり、
pnpm のポリシーと整合する。

## Test plan

- [ ] CI (lint / unit-test / e2e-test / commitlint) がすべて green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)